### PR TITLE
define Module_name

### DIFF
--- a/HaskellSpec/Names.lean
+++ b/HaskellSpec/Names.lean
@@ -11,6 +11,7 @@ Names are defined in Table 1 and Fig. 3 in the paper
 `M`
 -/
 inductive Module_Name : Type where
+  | Mk : String -> Module_Name
 
 /--
 `v`


### PR DESCRIPTION
I was a bit confused that there is apparently no lexical structure defined for module names.