### PR TITLE
Use fromInteger and fromRational for numeric literals

### DIFF
--- a/HaskellSpec/Elaboration/Expressions.lean
+++ b/HaskellSpec/Elaboration/Expressions.lean
@@ -6,6 +6,20 @@ import HaskellSpec.Target.Lang
 import HaskellSpec.SemanticTypes
 import HaskellSpec.Elaboration.Modules
 
+def fromRationalAfterRatio (n d : Int) : Target.Expression :=
+  Target.Expression.app
+   (Target.Expression.var SemTy.prelude_fromrational)
+   (Target.Expression.app
+     (Target.Expression.app
+       (Target.Expression.var SemTy.ratio_percent)
+       (Target.Expression.lit (Target.Literal.integer n))
+     )
+     (Target.Expression.lit (Target.Literal.integer d)))
+
+def fromInteger (i : Int) : Target.Expression :=
+  Target.Expression.app
+    (Target.Expression.var SemTy.prelude_frominteger)
+    (Target.Expression.lit (Target.Literal.integer i))
 
 /--
 Cp. Fig 37
@@ -31,17 +45,17 @@ inductive literal : Env.IE
             (SemTy.TypeS.App SemTy.prelude_list SemTy.prelude_char)
 
   | LIT_INTEGER :
-    dict ie e [⟨SemTy.prelude_num, τ⟩] →
+    dict ie (fromInteger i) [⟨SemTy.prelude_num, τ⟩] →
     literal ie
             (Source.Literal.integer i)
-            _ -- Prelude!fromInteger τ e i
+            (fromInteger i)
             τ
 
   | LIT_FLOAT :
-    dict ie e [⟨SemTy.prelude_fractional, τ⟩] →
+    dict ie (fromRationalAfterRatio n d) [⟨SemTy.prelude_fractional, τ⟩] →
     literal ie
             (Source.Literal.float n d)
-            _ -- Prelude!fromRational τ e ((Ratio.%) n d)
+            (fromRationalAfterRatio n d)
             τ
 
 def unqual_var (var : QVariable) : Variable :=

--- a/HaskellSpec/SemanticTypes.lean
+++ b/HaskellSpec/SemanticTypes.lean
@@ -33,6 +33,9 @@ inductive Class_Name : Type where
 def hs_prelude : Module_Name :=
   Module_Name.Mk "Prelude"
 
+def hs_ratio : Module_Name :=
+  Module_Name.Mk "Ratio"
+
 def prelude_eq : Class_Name :=
   Class_Name.Mk (OClass_Name.Qualified hs_prelude (_root_.Class_Name.Mk
   "Eq")) Kind.Star
@@ -73,6 +76,15 @@ def prelude_enum_from_to : QVariable :=
 
 def prelude_enum_from_then_to : QVariable :=
   QVariable.Qualified hs_prelude (Variable.Mk "enumFromThenTo")
+
+def prelude_frominteger : QVariable :=
+  QVariable.Qualified hs_prelude (Variable.Mk "fromInteger")
+
+def prelude_fromrational : QVariable :=
+  QVariable.Qualified hs_prelude (Variable.Mk "fromRational")
+
+def ratio_percent : QVariable :=
+  QVariable.Qualified hs_ratio (Variable.Mk "(%)")
 
 /--
 ```text

--- a/HaskellSpec/Target/Lang.lean
+++ b/HaskellSpec/Target/Lang.lean
@@ -19,7 +19,6 @@ inductive Literal : Type where
   | char : Char → Literal
   | string : String → Literal
   | integer : Int → Literal
-  | float : Int → Int → Literal
 
 
 /--


### PR DESCRIPTION
I think there is no need for floating point numbers in the target language, since they are desugered to regular integers passed to `Ratio.(%)`. So I've removed this constructor in this PR.
