### PR TITLE
make Context a type synonym

### DIFF
--- a/HaskellSpec/Elaboration/Expressions.lean
+++ b/HaskellSpec/Elaboration/Expressions.lean
@@ -78,7 +78,7 @@ inductive pat : Env.GE → Env.IE
               → SemTy.TypeS
               → Prop where
   | PVAR :
-    σ = (SemTy.TypeScheme.Forall [] (SemTy.Context.Mk []) τ) →
+    σ = (SemTy.TypeScheme.Forall [] [] τ) →
     pat
       ge
       ie

--- a/HaskellSpec/Elaboration/Modules.lean
+++ b/HaskellSpec/Elaboration/Modules.lean
@@ -223,7 +223,7 @@ IE ⊢ e : (Γ₁ τ₁,…,Γₙ τₙ)
 -/
 inductive dict : Env.IE
                → Target.Expression
-               → List (SemTy.Class_Name × SemTy.TypeS)
+               → SemTy.Context
                → Prop where
   | DICT_TUPLE :
     dict _ _ _

--- a/HaskellSpec/SemanticTypes.lean
+++ b/HaskellSpec/SemanticTypes.lean
@@ -143,8 +143,8 @@ TypeS.TypeConstructor (Type_Constructor.Mk (OType_Name.Special Special_Type_Cons
 θ ∈ Context → (Γ₁ τ₁, … , Γₙ τₙ)
 ```
 -/
-inductive Context : Type where
-  | Mk : List (Class_Name × TypeS) → Context
+
+def Context := List (Class_Name × TypeS)
 
 /--
 ```text


### PR DESCRIPTION
I don't think we need `Context` to be an inductive type, it can be a synonym for a `List` type (like `Env`).

I want to use this simplification in https://github.com/BinderDavid/haskell-spec/pull/57