### PR TITLE
Add python3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@ rec {
     hash = "sha256-6XFcyqSTx1CwNWqQvIc25cuQMwh3YXnbgr5cDiOCxBk=";
   };
   shell = mkShell {
-    nativeBuildInputs = [ elan steam-run ];
+    nativeBuildInputs = [ elan steam-run python3 ];
     shellHook =
      ''
       ## It should be enough to add


### PR DESCRIPTION
We add python3 to the nix shell to be able to serve docs locally.